### PR TITLE
srvs for loading/stopping/starting individual monitors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ add_message_files(
 
 add_service_files(
   FILES
+  LoadMonitors.srv
   GetTopicMaps.srv
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ add_message_files(
 
 add_service_files(
   FILES
-  LoadMonitors.srv
+  Client.srv
   GetTopicMaps.srv
 )
 

--- a/config/execute.yaml
+++ b/config/execute.yaml
@@ -2,7 +2,7 @@
 
 - name: "/current_node"
   signal_lambdas:
-  - expression: "lambda msg: msg.data == 'r1-ca'"
+  - expression: "lambda msg: msg.data == 'r1-cb'"
     safety_critical: True
     process_indices: [0,1,2,3,4,5]
     repeat_exec: False

--- a/config/execute.yaml
+++ b/config/execute.yaml
@@ -2,7 +2,7 @@
 
 - name: "/current_node"
   signal_lambdas:
-  - expression: "lambda msg: msg.data == 't1-r1-c1'"
+  - expression: "lambda msg: msg.data == 'r1-ca'"
     safety_critical: True
     process_indices: [0,1,2,3,4,5]
     repeat_exec: False

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -11,7 +11,6 @@
   signal_lambdas:
   - expression: "lambda msg : msg.data == False"
     timeout: 5.0
-    safety_critical: True
     autonomy_critical: True
     process_indices: [1]
     tags: ["expression 1"]
@@ -36,8 +35,7 @@
   signal_lambdas:
   - expression: "lambda msg : msg.data == False"
     timeout: 10.0
-    safety_critical: True
-    autonomy_critical: False
+    autonomy_critical: True
     process_indices: [1]
     tags: ["expression 2"]
   execute:

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -23,6 +23,7 @@
       message: "expression 1 is False"
       level: "warn"
   default_notifications: False
+  tags: ["expr_1", "test_1"]
 
 
 - name : "/expr_2"
@@ -47,6 +48,7 @@
       message: "expression 2 is False"
       level: "warn"
   default_notifications: False
+  tags: ["expr_2", "test_2"]
 
 
 - name: "/safe_operation"
@@ -64,6 +66,7 @@
       level: info
   timeout: 0.1
   default_notifications: False
+  tags: ["safe_op", "test_1"]
 
 
 - name: "/pause_autonomous_operation"
@@ -81,4 +84,6 @@
       level: info
   timeout: 0.1
   default_notifications: False
+  tags: ["pause_op", "test_2"]
+
 

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -23,7 +23,7 @@
       message: "expression 1 is False"
       level: "warn"
   default_notifications: False
-  tags: ["expr_1", "test_1"]
+  topic_tags: ["expr_1", "test_1"]
 
 
 - name : "/expr_2"
@@ -48,7 +48,7 @@
       message: "expression 2 is False"
       level: "warn"
   default_notifications: False
-  tags: ["expr_2", "test_2"]
+  topic_tags: ["expr_2", "test_2"]
 
 
 - name: "/safe_operation"
@@ -66,7 +66,7 @@
       level: info
   timeout: 0.1
   default_notifications: False
-  tags: ["safe_op", "test_1"]
+  topic_tags: ["safe_op", "test_1"]
 
 
 - name: "/pause_autonomous_operation"
@@ -84,6 +84,6 @@
       level: info
   timeout: 0.1
   default_notifications: False
-  tags: ["pause_op", "test_2"]
+  topic_tags: ["pause_op", "test_2"]
 
 

--- a/launch/sentor.launch
+++ b/launch/sentor.launch
@@ -1,7 +1,6 @@
 <?xml version="1.0" ?>
 <launch>
 
-  <arg name="topics" default=""/>
   <arg name="config_file" default=""/>
   <arg name="safe_operation_timeout" default="10.0"/>
   <arg name="auto_safety_tagging" default="true"/>

--- a/launch/sentor.launch
+++ b/launch/sentor.launch
@@ -7,6 +7,7 @@
   <arg name="safety_pub_rate" default="10.0"/>
   <arg name="independent_tags" default="false"/>
   <arg name="auto_topic" default="auto_mode"/>
+  <arg name="topic_tags" default="[]"/>
 
 
   <node pkg="sentor" type="sentor_node.py" name="sentor" output="screen">
@@ -16,6 +17,7 @@
     <param name="~safety_pub_rate" value="$(arg safety_pub_rate)" />
     <param name="~independent_tags" value="$(arg independent_tags)" />
     <param name="~auto_topic" value="$(arg auto_topic)" />
+    <rosparam param="topic_tags" subst_value="True">$(arg topic_tags)</rosparam>
   </node>	
 
 </launch>

--- a/msg/Monitor.msg
+++ b/msg/Monitor.msg
@@ -2,6 +2,7 @@ string topic
 string condition
 bool safety_critical
 bool autonomy_critical
+string[] tags
+string[] topic_tags
 bool satisfied
 bool active
-string[] tags

--- a/msg/Monitor.msg
+++ b/msg/Monitor.msg
@@ -3,4 +3,5 @@ string condition
 bool safety_critical
 bool autonomy_critical
 bool satisfied
+bool active
 string[] tags

--- a/scripts/sentor_client.py
+++ b/scripts/sentor_client.py
@@ -13,12 +13,12 @@ from sentor.srv import Client, ClientRequest
 def usage():
     print("\nLoads/stops/starts topic monitors:")
     print("\nFor loading monitors:")
-    print("\t rosrun sentor sentor_client.py load CONFIG TAG1 TAG2 TAGN")
+    print("\t rosrun sentor sentor_client.py load CONFIG TOPIC_TAG_1 TOPIC_TAG_2 TOPIC_TAG_N")
     print("\nFor stopping monitors:")
-    print("\t rosrun sentor sentor_client.py stop TAG1 TAG2 TAGN")
+    print("\t rosrun sentor sentor_client.py stop TOPIC_TAG_1 TOPIC_TAG_2 TOPIC_TAG_N")
     print("\nFor starting monitors:")
-    print("\t rosrun sentor sentor_client.py start TAG1 TAG2 TAGN")
-    print("\nTags are optional args used to load/stop/start specific monitors")
+    print("\t rosrun sentor sentor_client.py start TOPIC_TAG_1 TOPIC_TAG_2 TOPIC_TAG_N")
+    print("\nTopic tags are optional args used to load/stop/start specific monitors")
     print("\n\n")
     
     

--- a/scripts/sentor_client.py
+++ b/scripts/sentor_client.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Jul  1 09:25:27 2022
+
+@author: Adam Binch (abinch@sagarobotics.com)
+"""
+###################################################################################################################
+import rospy, sys
+from sentor.srv import Client, ClientRequest
+
+
+def usage():
+    print("\nLoads/stops/starts topic monitors:")
+    print("\nFor loading monitors:")
+    print("\t rosrun sentor sentor_client.py load CONFIG TAG1 TAG2 TAGN")
+    print("\nFor stopping monitors:")
+    print("\t rosrun sentor sentor_client.py stop TAG1 TAG2 TAGN")
+    print("\nFor starting monitors:")
+    print("\t rosrun sentor sentor_client.py start TAG1 TAG2 TAGN")
+    print("\nTags are optional args used to load/stop/start specific monitors")
+    print("\n\n")
+    
+    
+def sentor_client(mode, config, tags):
+    
+    rospy.wait_for_service(mode, timeout=5.0)
+    try:
+        s = rospy.ServiceProxy(mode, Client)
+        req = ClientRequest()
+        req.config = config
+        req.topic_tags = tags
+        resp = s.call(req)
+        rospy.loginfo(resp)
+    except rospy.ServiceException as e:
+        print("Service call failed: {}".format(e))
+###################################################################################################################
+    
+    
+###################################################################################################################
+if __name__ == "__main__":
+    
+    if '-h' in sys.argv or '--help' in sys.argv or len(sys.argv) < 2:
+        usage()
+        sys.exit(1)
+    else:
+        mode = ""
+        config = ""
+        tags = []
+        if sys.argv[1] == "load":
+            mode = "/sentor/load_monitors"
+            if len(sys.argv) > 2:
+                config = sys.argv[2]
+                if len(sys.argv) > 3:
+                    tags = sys.argv[3:]
+            else:
+                usage()
+                sys.exit(1)
+        elif sys.argv[1] == "stop":
+            mode = "/sentor/stop_monitors"
+            if len(sys.argv) > 2:
+                tags = sys.argv[2:]
+        elif sys.argv[1] == "start":
+            mode = "/sentor/start_monitors"
+            if len(sys.argv) > 2:
+                tags = sys.argv[2:]
+        else:
+            usage()
+            sys.exit(1)
+
+    rospy.init_node("sentor_client")
+    sentor_client(mode, config, tags)
+###################################################################################################################

--- a/scripts/sentor_node.py
+++ b/scripts/sentor_node.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
-@author: Francesco Del Duchetto (FDelDuchetto@lincoln.ac.uk)
 @author: Adam Binch (abinch@sagarobotics.com)
+@author: Francesco Del Duchetto (FDelDuchetto@lincoln.ac.uk)
 """
 ##########################################################################################
 from __future__ import division
@@ -11,171 +11,176 @@ from sentor.MultiMonitor import MultiMonitor
 from std_msgs.msg import String
 from sentor.msg import SentorEvent
 from std_srvs.srv import Empty, EmptyResponse
-import pprint
+
 import signal
 import rospy
 import time
 import yaml
-import sys
 import os
+##########################################################################################
 
-# TODO nice printing of frequency of the topic with curses
-# TODO consider timeout
 
-unpublished_topics_indexes = []
-satisfied_filters_indexes = []
-
-topic_monitors = []
-
-event_pub = None
-rich_event_pub = None
-
-def __signal_handler(signum, frame):
-
-    def kill_monitors():
-        for topic_monitor in topic_monitors:
-            topic_monitor.kill_monitor()
-
-        safety_monitor.stop_monitor()
-        autonomy_monitor.stop_monitor()
-        multi_monitor.stop_monitor()
-
-    def join_monitors():
-        for topic_monitor in topic_monitors:
-            topic_monitor.join()
-
-    kill_monitors()
-    join_monitors()
-    print("stopped.")
-    os._exit(signal.SIGTERM)
+##########################################################################################
+class sentor(object):
     
-
-def stop_monitoring(_):
-    for topic_monitor in topic_monitors:
-        topic_monitor.stop_monitor()
+    def __init__(self):
         
-    safety_monitor.stop_monitor()
-    autonomy_monitor.stop_monitor()
-    multi_monitor.stop_monitor()
+        self.topics = []
+        self.topic_monitors = []
+        
+        signal.signal(signal.SIGINT, self.__signal_handler)
+        
+        self.safety_monitor = SafetyMonitor("safe_operation", "SAFE OPERATION", "thread_is_safe", "safety_critical", 
+                                       "set_safety_tag", self.event_callback)
+        self.autonomy_monitor = SafetyMonitor("pause_autonomous_operation", "SAFE AUTONOMOUS OPERATION", "thread_is_auto", 
+                                         "autonomy_critical", "set_autonomy_tag", self.event_callback, invert=True)
+        self.multi_monitor = MultiMonitor()
+        
+        self.event_pub = rospy.Publisher('/sentor/event', String, queue_size=10)
+        self.rich_event_pub = rospy.Publisher('/sentor/rich_event', SentorEvent, queue_size=10)
+        
+        self.load_topics()
+        self.instantiate()
+        
+        rospy.Service('/sentor/stop_monitor', Empty, self.stop_monitoring)
+        rospy.Service('/sentor/start_monitor', Empty, self.start_monitoring)
+        
+        rospy.spin()
+        
+        
+    def __signal_handler(self, signum, frame):
 
-    rospy.logwarn("sentor_node stopped monitoring")
-    ans = EmptyResponse()
-    return ans
+        def kill_monitors():
+            for topic_monitor in self.topic_monitors:
+                topic_monitor.kill_monitor()
     
-
-def start_monitoring(_):    
-    for topic_monitor in topic_monitors:
-        topic_monitor.start_monitor()
-
-    safety_monitor.start_monitor()
-    autonomy_monitor.start_monitor()
-    multi_monitor.start_monitor()
-
-    rospy.logwarn("sentor_node started monitoring")
-    ans = EmptyResponse()
-    return ans
+            self.safety_monitor.stop_monitor()
+            self.autonomy_monitor.stop_monitor()
+            self.multi_monitor.stop_monitor()
     
-
-def event_callback(string, type, msg="", nodes=[], topic=""):
-    if type == "info":
-        rospy.loginfo(string + '\n' + str(msg))
-    elif type == "warn":
-        rospy.logwarn(string + '\n' + str(msg))
-    elif type == "error":
-        rospy.logerr(string + '\n' + str(msg))
-
-    if event_pub is not None:
-        event_pub.publish(String("%s: %s" % (type, string)))
-
-    if rich_event_pub is not None:
+        def join_monitors():
+            for topic_monitor in self.topic_monitors:
+                topic_monitor.join()
+    
+        kill_monitors()
+        join_monitors()
+        print("stopped.")
+        os._exit(signal.SIGTERM)
+        
+        
+    def load_topics(self):
+        
+        config_file = rospy.get_param("~config_file", "")
+        try:
+            items = [yaml.load(open(item, 'r')) for item in config_file.split(',')]
+            self.topics = [item for sublist in items for item in sublist]
+        except Exception as e:
+            rospy.logerr("No configuration file provided: %s" % e)
+            
+            
+    def instantiate(self):
+        
+        print("Monitoring topics:")
+        for i, topic in enumerate(self.topics):
+            
+            include = True
+            if 'include' in topic:
+                include = topic['include']
+                
+            if not include:
+                continue
+            
+            try:
+                topic_name = topic["name"]
+            except Exception:
+                rospy.logerr("topic name is not specified for entry %s" % topic)
+                continue
+    
+            rate = 0
+            N = 0
+            signal_when = {}
+            signal_lambdas = []
+            processes = []
+            timeout = 0
+            default_notifications = True
+            
+            if 'rate' in topic:
+                rate = topic['rate']
+            if 'N' in topic:
+                N = int(topic['N'])
+            if 'signal_when' in topic:
+                signal_when = topic['signal_when']
+            if 'signal_lambdas' in topic:
+                signal_lambdas = topic['signal_lambdas']
+            if 'execute' in topic:
+                processes = topic['execute']
+            if 'timeout' in topic:
+                timeout = topic['timeout']
+            if 'default_notifications' in topic:
+                default_notifications = topic['default_notifications']
+    
+            topic_monitor = TopicMonitor(topic_name, rate, N, signal_when, signal_lambdas, processes, 
+                                         timeout, default_notifications, self.event_callback, i)
+    
+            self.topic_monitors.append(topic_monitor)
+            self.safety_monitor.register_monitors(topic_monitor)
+            self.autonomy_monitor.register_monitors(topic_monitor)
+            self.multi_monitor.register_monitors(topic_monitor)
+            
+        time.sleep(1)
+        for topic_monitor in self.topic_monitors:
+            topic_monitor.start()
+        
+        
+    def event_callback(self, string, type, msg="", nodes=[], topic=""):
+        if type == "info":
+            rospy.loginfo(string + '\n' + str(msg))
+        elif type == "warn":
+            rospy.logwarn(string + '\n' + str(msg))
+        elif type == "error":
+            rospy.logerr(string + '\n' + str(msg))
+    
+        self.event_pub.publish(String("%s: %s" % (type, string)))
+    
         event = SentorEvent()
         event.header.stamp = rospy.Time.now()
         event.level = SentorEvent.INFO if type == "info" else SentorEvent.WARN if type == "warn" else SentorEvent.ERROR
         event.message = string
         event.nodes = nodes
         event.topic = topic
-        rich_event_pub.publish(event)
-##########################################################################################
+        self.rich_event_pub.publish(event)
+        
+        
+    def stop_monitoring(self):
+        for topic_monitor in self.topic_monitors:
+            topic_monitor.stop_monitor()
+            
+        self.safety_monitor.stop_monitor()
+        self.autonomy_monitor.stop_monitor()
+        self.multi_monitor.stop_monitor()
     
+        rospy.logwarn("sentor_node stopped monitoring")
+        ans = EmptyResponse()
+        return ans
+        
+    
+    def start_monitoring(self):    
+        for topic_monitor in self.topic_monitors:
+            topic_monitor.start_monitor()
+    
+        self.safety_monitor.start_monitor()
+        self.autonomy_monitor.start_monitor()
+        self.multi_monitor.start_monitor()
+    
+        rospy.logwarn("sentor_node started monitoring")
+        ans = EmptyResponse()
+        return ans
+##########################################################################################
+
 
 ##########################################################################################
 if __name__ == "__main__":
-    signal.signal(signal.SIGINT, __signal_handler)
-    rospy.init_node("sentor")
-
-    config_file = rospy.get_param("~config_file", "")
-    try:
-        items = [yaml.load(open(item, 'r')) for item in config_file.split(',')]
-        topics = [item for sublist in items for item in sublist]
-    except Exception as e:
-        rospy.logerr("No configuration file provided: %s" % e)
-        topics = []
-
-    stop_srv = rospy.Service('/sentor/stop_monitor', Empty, stop_monitoring)
-    start_srv = rospy.Service('/sentor/start_monitor', Empty, start_monitoring)
-
-    event_pub = rospy.Publisher('/sentor/event', String, queue_size=10)
-    rich_event_pub = rospy.Publisher('/sentor/rich_event', SentorEvent, queue_size=10)
     
-    safety_monitor = SafetyMonitor("safe_operation", "SAFE OPERATION", "thread_is_safe", "safety_critical", 
-                                   "set_safety_tag", event_callback)
-    autonomy_monitor = SafetyMonitor("pause_autonomous_operation", "SAFE AUTONOMOUS OPERATION", "thread_is_auto", 
-                                     "autonomy_critical", "set_autonomy_tag", event_callback, invert=True)
-    multi_monitor = MultiMonitor()
-
-    topic_monitors = []
-    print("Monitoring topics:")
-    for i, topic in enumerate(topics):
-        
-        include = True
-        if 'include' in topic:
-            include = topic['include']
-            
-        if not include:
-            continue
-        
-        try:
-            topic_name = topic["name"]
-        except Exception as e:
-            rospy.logerr("topic name is not specified for entry %s" % topic)
-            continue
-
-        rate = 0
-        N = 0
-        signal_when = {}
-        signal_lambdas = []
-        processes = []
-        timeout = 0
-        default_notifications = True
-        
-        if 'rate' in topic:
-            rate = topic['rate']
-        if 'N' in topic:
-            N = int(topic['N'])
-        if 'signal_when' in topic:
-            signal_when = topic['signal_when']
-        if 'signal_lambdas' in topic:
-            signal_lambdas = topic['signal_lambdas']
-        if 'execute' in topic:
-            processes = topic['execute']
-        if 'timeout' in topic:
-            timeout = topic['timeout']
-        if 'default_notifications' in topic:
-            default_notifications = topic['default_notifications']
-
-        topic_monitor = TopicMonitor(topic_name, rate, N, signal_when, signal_lambdas, processes, 
-                                     timeout, default_notifications, event_callback, i)
-
-        topic_monitors.append(topic_monitor)
-        safety_monitor.register_monitors(topic_monitor)
-        autonomy_monitor.register_monitors(topic_monitor)
-        multi_monitor.register_monitors(topic_monitor)
-            
-    time.sleep(1)
-
-    # start monitoring
-    for topic_monitor in topic_monitors:
-        topic_monitor.start()
-
-    rospy.spin()
+    rospy.init_node("sentor")
+    sentor()
 ##########################################################################################

--- a/scripts/sentor_node.py
+++ b/scripts/sentor_node.py
@@ -171,7 +171,7 @@ class sentor(object):
         
         success = False
         for monitor in self.topic_monitors_all:
-            if req.topic_tags[0]:
+            if req.topic_tags and req.topic_tags[0]:
                 if any(tag in monitor.topic_tags for tag in req.topic_tags):
                     monitor.stop_monitor()
                     success = True
@@ -190,7 +190,7 @@ class sentor(object):
         
         success = False
         for monitor in self.topic_monitors_all:
-            if req.topic_tags[0]:
+            if req.topic_tags and req.topic_tags[0]:
                 if any(tag in monitor.topic_tags for tag in req.topic_tags):
                     monitor.start_monitor()
                     success = True

--- a/scripts/sentor_node.py
+++ b/scripts/sentor_node.py
@@ -65,7 +65,7 @@ class sentor(object):
                 self.topics = filtered_topics
             
         except Exception as e:
-            rospy.logerr("No configuration file provided: %s" % e)
+            rospy.logerr("Error loading configuration file: {}".format(e))
             
             
     def instantiate(self):

--- a/scripts/sentor_node.py
+++ b/scripts/sentor_node.py
@@ -11,7 +11,7 @@ from sentor.MultiMonitor import MultiMonitor
 from std_msgs.msg import String
 from sentor.msg import SentorEvent
 from std_srvs.srv import Empty, EmptyResponse
-from sentor.srv import LoadMonitors
+from sentor.srv import Client
 
 import signal
 import rospy
@@ -40,7 +40,7 @@ class sentor(object):
         self.load_topics(config_file, tags)
         self.instantiate()
         
-        rospy.Service('/sentor/load_monitors', LoadMonitors, self.load_monitors)
+        rospy.Service('/sentor/load_monitors', Client, self.load_monitors)
         rospy.Service('/sentor/stop_monitor', Empty, self.stop_monitoring)
         rospy.Service('/sentor/start_monitor', Empty, self.start_monitoring)
         
@@ -76,10 +76,10 @@ class sentor(object):
             items = [yaml.load(open(item, 'r')) for item in config_file.split(',')]
             self.topics = [item for sublist in items for item in sublist]
             
-            if tags:
+            if tags and tags[0]:
                 filtered_topics = []
                 for topic in self.topics:
-                    if "tags" in topic and any(tag in topic["tags"] for tag in tags):
+                    if "topic_tags" in topic and any(tag in topic["topic_tags"] for tag in tags):
                         filtered_topics.append(topic)
 
                 self.topics = filtered_topics
@@ -165,7 +165,7 @@ class sentor(object):
     def load_monitors(self, req):
         
         try:
-            self.load_topics(req.config, req.tags)
+            self.load_topics(req.config, req.topic_tags)
             self.instantiate()
             return True
         except Exception as e:

--- a/scripts/sentor_node.py
+++ b/scripts/sentor_node.py
@@ -173,26 +173,24 @@ class sentor(object):
             return False
         
         
-    def stop_monitoring(self):
+    def stop_monitoring(self, req):
         for topic_monitor in self.topic_monitors:
             topic_monitor.stop_monitor()
             
         self.safety_monitor.stop_monitor()
         self.autonomy_monitor.stop_monitor()
-        self.multi_monitor.stop_monitor()
     
         rospy.logwarn("sentor_node stopped monitoring")
         ans = EmptyResponse()
         return ans
         
     
-    def start_monitoring(self):    
+    def start_monitoring(self, req):    
         for topic_monitor in self.topic_monitors:
             topic_monitor.start_monitor()
     
         self.safety_monitor.start_monitor()
         self.autonomy_monitor.start_monitor()
-        self.multi_monitor.start_monitor()
     
         rospy.logwarn("sentor_node started monitoring")
         ans = EmptyResponse()

--- a/src/sentor/CustomLambdaExample.py
+++ b/src/sentor/CustomLambdaExample.py
@@ -13,5 +13,5 @@ class CustomLambda(object):
         pass
         
     def run(self, msg):
-        return msg.data == "r1-cz"
+        return msg.data == "r1-cy"
 #########################################################################################################

--- a/src/sentor/CustomLambdaExample.py
+++ b/src/sentor/CustomLambdaExample.py
@@ -7,6 +7,11 @@ Created on Fri Nov 20 11:35:22 2020
 #########################################################################################################
 # SENTOR CUSTOM LAMBDA
 
-def CustomLambda(msg):
-    return msg.data == "t1-r1-c2"
+class CustomLambda(object):
+    
+    def __init__(self):
+        pass
+        
+    def run(self, msg):
+        return msg.data == False
 #########################################################################################################

--- a/src/sentor/CustomLambdaExample.py
+++ b/src/sentor/CustomLambdaExample.py
@@ -13,5 +13,5 @@ class CustomLambda(object):
         pass
         
     def run(self, msg):
-        return msg.data == False
+        return msg.data == "r1-cz"
 #########################################################################################################

--- a/src/sentor/MultiMonitor.py
+++ b/src/sentor/MultiMonitor.py
@@ -21,6 +21,7 @@ class MultiMonitor(object):
         self.topic_monitors = []
         self._stop_event = Event()
         self.error_code = []
+        self.actives = []
         
         self.monitors_pub = rospy.Publisher("/sentor/monitors", MonitorArray, latch=True, queue_size=1)
         rospy.Timer(rospy.Duration(1.0/rate), self.callback)
@@ -35,9 +36,11 @@ class MultiMonitor(object):
         if not self._stop_event.isSet():
             
             error_code_new = [monitor.conditions[expr]["satisfied"] for monitor in self.topic_monitors for expr in monitor.conditions]
+            actives_new = [monitor.active for monitor in self.topic_monitors]
             
-            if error_code_new != self.error_code:
+            if error_code_new != self.error_code or actives_new != self.actives:
                 self.error_code = error_code_new
+                self.actives = actives_new
                 
                 conditions = MonitorArray()
                 conditions.header.stamp = rospy.Time.now()
@@ -45,7 +48,8 @@ class MultiMonitor(object):
                 count = 0                
                 for monitor in self.topic_monitors:
                     topic_name = monitor.topic_name
-                    
+                    active = monitor.active
+                        
                     for expr in monitor.conditions:
                         condition = Monitor()
                         condition.topic = topic_name
@@ -54,6 +58,7 @@ class MultiMonitor(object):
                         condition.autonomy_critical = monitor.conditions[expr]["autonomy_critical"]
                         condition.satisfied = self.error_code[count]
                         condition.tags = monitor.conditions[expr]["tags"]
+                        condition.active = active
                         conditions.conditions.append(condition)
                         count+=1
                         

--- a/src/sentor/MultiMonitor.py
+++ b/src/sentor/MultiMonitor.py
@@ -48,6 +48,7 @@ class MultiMonitor(object):
                 count = 0                
                 for monitor in self.topic_monitors:
                     topic_name = monitor.topic_name
+                    topic_tags = monitor.topic_tags
                     active = monitor.active
                         
                     for expr in monitor.conditions:
@@ -56,8 +57,9 @@ class MultiMonitor(object):
                         condition.condition = expr
                         condition.safety_critical = monitor.conditions[expr]["safety_critical"]
                         condition.autonomy_critical = monitor.conditions[expr]["autonomy_critical"]
-                        condition.satisfied = self.error_code[count]
                         condition.tags = monitor.conditions[expr]["tags"]
+                        condition.topic_tags = topic_tags
+                        condition.satisfied = self.error_code[count]
                         condition.active = active
                         conditions.conditions.append(condition)
                         count+=1

--- a/src/sentor/MultiMonitor.py
+++ b/src/sentor/MultiMonitor.py
@@ -24,6 +24,7 @@ class MultiMonitor(object):
         self.actives = []
         
         self.monitors_pub = rospy.Publisher("/sentor/monitors", MonitorArray, latch=True, queue_size=1)
+        self.monitors_pub.publish(MonitorArray())
         rospy.Timer(rospy.Duration(1.0/rate), self.callback)
 
 

--- a/src/sentor/SafetyMonitor.py
+++ b/src/sentor/SafetyMonitor.py
@@ -73,7 +73,7 @@ class SafetyMonitor(object):
         if not self._stop_event.isSet():
 
             if self.topic_monitors:
-                threads_are_safe = [getattr(monitor, self.attr) for monitor in self.topic_monitors]
+                threads_are_safe = [getattr(monitor, self.attr) for monitor in self.topic_monitors if monitor.active]
                 self.bad_monitors = [i for i, item in enumerate(threads_are_safe) if not item]
                 
                 if self.auto_tagging and all(threads_are_safe) and self.timer is None:

--- a/src/sentor/TopicMonitor.py
+++ b/src/sentor/TopicMonitor.py
@@ -17,6 +17,7 @@ import rospy
 import time
 import subprocess
 import os
+import uuid
 
 class bcolors:
     HEADER = '\033[95m'
@@ -103,8 +104,10 @@ class TopicMonitor(Thread):
         
         # if rate > 0 set in config then throttle topic at that rate
         if self.rate > 0:
+            _id = "".join(str(uuid.uuid4()).split("-"))
+            
             COMMAND_BASE = ["rosrun", "topic_tools", "throttle"]
-            subscribed_topic = "/sentor/monitoring/" + str(self.thread_num) + real_topic
+            subscribed_topic = "/sentor/monitoring/" + _id + real_topic
             
             command = COMMAND_BASE + ["messages", real_topic, str(self.rate), subscribed_topic]
             subprocess.Popen(command, stdout=open(os.devnull, "wb"))

--- a/src/sentor/TopicMonitor.py
+++ b/src/sentor/TopicMonitor.py
@@ -36,7 +36,7 @@ class TopicMonitor(Thread):
 
 
     def __init__(self, topic_name, rate, N, signal_when_config, signal_lambdas_config, processes, 
-                 timeout, default_notifications, event_callback, thread_num):
+                 timeout, default_notifications, event_callback, topic_tags):
         Thread.__init__(self)
 
         self.topic_name = topic_name
@@ -51,7 +51,7 @@ class TopicMonitor(Thread):
             self.timeout = 0.1
         self.default_notifications = default_notifications
         self._event_callback = event_callback
-        self.thread_num = thread_num
+        self.topic_tags = topic_tags
         
         self.independent_tags = rospy.get_param("~independent_tags", False)
         

--- a/src/sentor/TopicMonitor.py
+++ b/src/sentor/TopicMonitor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
-@author: Francesco Del Duchetto (FDelDuchetto@lincoln.ac.uk)
 @author: Adam Binch (abinch@sagarobotics.com)
+@author: Francesco Del Duchetto (FDelDuchetto@lincoln.ac.uk)
 """
 #####################################################################################
 from sentor.ROSTopicHz import ROSTopicHz
@@ -237,6 +237,8 @@ class TopicMonitor(Thread):
         lambda_config["expr"] = ""
         lambda_config["file"] = None
         lambda_config["package"] = None
+        lambda_config["init_args"] = None
+        lambda_config["run_args"] = None
         lambda_config["timeout"] = self.timeout
         lambda_config["safety_critical"] = False
         lambda_config["autonomy_critical"] = False
@@ -253,6 +255,10 @@ class TopicMonitor(Thread):
             lambda_config["file"] = signal_lambda["file"]
         if "package" in signal_lambda:
             lambda_config["package"] = signal_lambda["package"]
+        if "init_args" in signal_lambda:
+            lambda_config["init_args"] = signal_lambda["init_args"]
+        if "run_args" in signal_lambda:
+            lambda_config["run_args"] = signal_lambda["run_args"]
         if "timeout" in signal_lambda:
             lambda_config["timeout"] = signal_lambda["timeout"]
         if "safety_critical" in signal_lambda:
@@ -314,16 +320,16 @@ class TopicMonitor(Thread):
         
 
     def _instantiate_lambda_monitor(self, subscribed_topic, msg_class, lambda_fn_str, lambda_config):
-        filter = ROSTopicFilter(self.topic_name, lambda_fn_str, lambda_config, lambda_config["N"])
+        _filter = ROSTopicFilter(self.topic_name, lambda_fn_str, lambda_config, lambda_config["N"])
 
         if lambda_config["N"] <= 0:
-            cb = filter.callback_filter
+            cb = _filter.callback_filter
         else:
-            cb = filter.callback_filter_throttled
+            cb = _filter.callback_filter_throttled
             
         rospy.Subscriber(subscribed_topic, msg_class, cb)
 
-        return filter
+        return _filter
         
 
     def run(self):

--- a/src/sentor/TopicMonitor.py
+++ b/src/sentor/TopicMonitor.py
@@ -83,6 +83,7 @@ class TopicMonitor(Thread):
         self.hz_monitor = None
         self.is_topic_published = True 
         self.is_instantiated = False
+        self.active = False
         self.is_instantiated = self._instantiate_monitors()
 
 
@@ -171,6 +172,7 @@ class TopicMonitor(Thread):
             print("")
 
         self.is_instantiated = True
+        self.active = True
 
         return True
     
@@ -502,10 +504,12 @@ class TopicMonitor(Thread):
             
             
     def stop_monitor(self):
+        self.active = False
         self._stop_event.set()
         
 
     def start_monitor(self):
+        self.active = True
         self._stop_event.clear()
         
 

--- a/srv/Client.srv
+++ b/srv/Client.srv
@@ -2,3 +2,4 @@ string config   # used only by service /sentor/load_monitors
 string[] topic_tags
 ---
 bool success
+string message

--- a/srv/Client.srv
+++ b/srv/Client.srv
@@ -1,0 +1,4 @@
+string config   # used only by service /sentor/load_monitors
+string[] topic_tags
+---
+bool success

--- a/srv/Client.srv
+++ b/srv/Client.srv
@@ -2,4 +2,4 @@ string config   # used only by service /sentor/load_monitors
 string[] topic_tags
 ---
 bool success
-string message
+sentor/MonitorArray monitors

--- a/srv/LoadMonitors.srv
+++ b/srv/LoadMonitors.srv
@@ -1,4 +1,0 @@
-string config
-string[] tags
----
-bool success

--- a/srv/LoadMonitors.srv
+++ b/srv/LoadMonitors.srv
@@ -1,0 +1,4 @@
+string config
+string[] tags
+---
+bool success


### PR DESCRIPTION
Service `/sentor/load_monitors` for loading monitors with srv `sentor.srv.Client`
```
string config   # used only by service /sentor/load_monitors
string[] topic_tags
---
bool success
sentor/MonitorArray monitors
 ``` 

Can provide a list of tags (`topic_tags`) e.g. https://github.com/adambinch/sentor/blob/5e9bf236218ab4a38a61985c2ca178750d06a027/config/test.yaml#L25 in the yaml config for each monitor. In the service call load specific monitors by using the optional `topic_tags` field. These tags work like the tags used in TMuLE.

Similarly for the start/stop monitors services (also using `sentor.srv.Client`), tags can be given in the service call so that specific monitors are stopped or started.

To keep track of which monitors are currently active, the latest msg from the topic `/sentor/monitors` is given as the service response.

Rather than calling these services directly, they can be called by running the client node 

```
rosrun sentor sentor_client.py --help

Loads/stops/starts topic monitors:

For loading monitors:
	 rosrun sentor sentor_client.py load CONFIG TOPIC_TAG_1 TOPIC_TAG_2 TOPIC_TAG_N

For stopping monitors:
	 rosrun sentor sentor_client.py stop TOPIC_TAG_1 TOPIC_TAG_2 TOPIC_TAG_N

For starting monitors:
	 rosrun sentor sentor_client.py start TOPIC_TAG_1 TOPIC_TAG_2 TOPIC_TAG_N

Topic tags are optional args used to load/stop/start specific monitors
```

Also custom lambdas are now implemented as classes, similar to custom processes