### PR TITLE
Replace install -> catkin_install_python in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ catkin_package(
 )
 
 catkin_install_python(PROGRAMS
+  scripts/sentor_client.py
   scripts/sentor_node.py
   scripts/topic_mapping_node.py
   scripts/test.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ catkin_package(
   CATKIN_DEPENDS message_runtime
 )
 
-install(PROGRAMS
+catkin_install_python(PROGRAMS
   scripts/sentor_node.py
   scripts/topic_mapping_node.py
   scripts/test.py


### PR DESCRIPTION
This change makes sure that when catkin builds the package, any `#!/usr/bin/env python` is replaced with the default python version for the relevant ROS distribution, instead of requiring Python2. Meaning as long as the code itself is compatible with Python3, there's no need to change the shebang for it to work with Noetic.

See docs here: http://docs.ros.org/en/jade/api/catkin/html/howto/format2/installing_python.html